### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Customizable & Expandable Calendar Widget for Android
 
-##Project Components
+## Project Components
 mCalendarView provide below components.
 
 * mCalendarView, which is our customizable calendar widget.
@@ -25,14 +25,14 @@ Class `ExpCalendarView` is for expandable calendar view.
 
 Expandable calendar view is contributed by my homie [mBigMing](https://github.com/mBigFlower). Big thank you for that.
 
-##Screenshots
+## Screenshots
 I used Android built-in `screenrecord` command to get the screenshot. But for some reason I don't know, the screen color is weird...
 
 ![Alt ](./screenshot/shot.gif)
 ![Alt ](./screenshot/exp.gif)
-##Usage
+## Usage
 
-###Download
+### Download
 Add dependency to your `build.gradle`
 
     ```
@@ -41,12 +41,12 @@ Add dependency to your `build.gradle`
     }
     ```
 
-###Add to Layout
+### Add to Layout
 To use mCalendarView, you need to add it in layout by using xml file or Java code. 
 
-####Add normal calendarview
+#### Add normal calendarview
 
-######Make sure you specifiy an `FragmentActivity` or it's sub-class as mCalendarView's context.
+###### Make sure you specifiy an `FragmentActivity` or it's sub-class as mCalendarView's context.
 
 	    <sun.bob.mcalendarview.mCalendarView
         android:layout_width="400dp"
@@ -55,7 +55,7 @@ To use mCalendarView, you need to add it in layout by using xml file or Java cod
         android:id="@+id/calendar"
         />
         
-####Add expandable calendarview
+#### Add expandable calendarview
 
     <sun.bob.mcalendarview.views.ExpCalendarView
         android:id="@+id/calendar_exp"
@@ -63,13 +63,13 @@ To use mCalendarView, you need to add it in layout by using xml file or Java cod
         android:layout_height="wrap_content"
         tools:context=".MainActivity" />
         
-###Jump to Date
+### Jump to Date
 By default, mCalendarView will display current month. If you what to jump to another month, use `travelTo(DateData date)` function in mCalendarView.
 
 	mCalendarView calendarView = ((mCalendarView) findViewById(R.id.calendar));
 	calendarView.travelTo(new DateData(1992, 5, 5));
 	
-###Mark / Highlight a Date
+### Mark / Highlight a Date
 Android's built-in widget dosen't have this feature, that's why I'm writing this widget.
 
 There are two method in mCalendarViewClass to highlight a date.
@@ -91,7 +91,7 @@ Below function will let you specify a customized hightlight style and color.
 		new DateData(2016, 3, 1).setMarkStyle(new MarkStyle(MarkStyle.DOT, Color.GREEN)
 	);
 	
-###Use built-in Mark Styles
+### Use built-in Mark Styles
 
 mCalendarView provide below built-in mark styles. Mark styles are defined in class `MarkStyle`.
 
@@ -121,7 +121,7 @@ To specify a highlight style and color for one day, use `setMarkStyle(MarkStyle 
 
 You can get screenshots of each mark styles in `More ScreenShots` Section
 
-###Use Customize Date Cell
+### Use Customize Date Cell
 mCalendarView allows you using your own views for date cells, but there are some restrictions.
 
 * Your customized view must extend `BaseCellView`, which inherit from `LinearLayout`.
@@ -162,14 +162,14 @@ mCalendarView allows you using your own views for date cells, but there are some
 		mCalendarView calendarView = ((mCalendarView) findViewById(R.id.calendar));
 		calendarView.setDateCell(R.layout.layout_date_cell)
 		
-###Use Customized Mark Cell
+### Use Customized Mark Cell
 mCalendar allows you using your own views for marked / highlighted date cells.
 
 To use this feature, your view need to extend `BaseMarkView`.
 
 The rest parts are the same with `Use Customized Date Cell`.
 
-###Set OnMonthChangeListener
+### Set OnMonthChangeListener
 `OnMonthChangeListener` is an abstract class and will be invoked when user sliding right or left to change month. It will provide value of current year and month as parameter.
 
 	public abstract void onMonthChange(int year, int month);
@@ -183,7 +183,7 @@ To set an OnMonthChangeListener, extend this class and call `setOnMonthChangeLis
             }
         });
         
-###Set OnDateClickListener
+### Set OnDateClickListener
 `OnDateClickListener` is an abstract class and will be invoked when use click on date cells. It will provide a `DateData` as parameter.
 
 	public abstract void onDateClick(View view,DateData date);
@@ -197,47 +197,47 @@ To set an OnDateClickListener, extend this class and call `setOnDateClickListene
             }
         });
         
-###Expand & Shrink
+### Expand & Shrink
 
 	expCalendarView.expand();
 	expCalendarView.shrink();
         
-#More Screenshots
-####MarkStyle.BACKGROUND
+# More Screenshots
+#### MarkStyle.BACKGROUND
 ![Alt ](./screenshot/MarkStyle.BACKGROUND.png)
 
-####MarkStyle.DOT
+#### MarkStyle.DOT
 
 ![Alt ](./screenshot/MarkStyle.DOT.png)
 
-####MarkStyle.LEFTSIDEBAR
+#### MarkStyle.LEFTSIDEBAR
 
 ![Alt](./screenshot/MarkStyle.LEFTSIDEBAR.png)
 
-####MarkStyle.RIGHTSIDEBAR
+#### MarkStyle.RIGHTSIDEBAR
 
 ![Alt](./screenshot/MarkStyle.RIGHTSIDEBAR.png)
 
-#Credits
+# Credits
 
-###[mBigMing](https://github.com/mBigFlower)
+### [mBigMing](https://github.com/mBigFlower)
 
 For Expandabel calendar view.
 
-###[oong](https://github.com/oong) & [Barry](https://github.com/fg2q1q3q)
+### [oong](https://github.com/oong) & [Barry](https://github.com/fg2q1q3q)
 
 For bug fix.
 
-###[Rodrigo Arantes](https://github.com/rodriggoarantes)
+### [Rodrigo Arantes](https://github.com/rodriggoarantes)
 
 For WeekColumnView Translate in ExpCalendarView.
 
 # APPs which using mCalendarView
-###[Natural Family Planning (NFP)](https://play.google.com/store/apps/details?id=com.projectcaruso.naturalfamilyplaning&hl=en)
+### [Natural Family Planning (NFP)](https://play.google.com/store/apps/details?id=com.projectcaruso.naturalfamilyplaning&hl=en)
 
-###[BeSAFE](https://play.google.com/store/apps/details?id=aman.sow.apps.besafe&hl=en)
+### [BeSAFE](https://play.google.com/store/apps/details?id=aman.sow.apps.besafe&hl=en)
 
-#License
+# License
 Copyright 2015 Bob Sun
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
