### PR TITLE
Choose which week to show after shrink()

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,15 +9,15 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name" >
+            android:label="@string/app_name" />
+
+        <activity android:name="sun.bob.mcalendarviewtest.ExpMainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
-        <activity android:name="sun.bob.mcalendarviewtest.ExpMainActivity"/>
         <activity android:name="sun.bob.mcalendarviewtest.TabActivity"/>
     </application>
 

--- a/app/src/main/java/sun/bob/mcalendarviewtest/ExpMainActivity.java
+++ b/app/src/main/java/sun/bob/mcalendarviewtest/ExpMainActivity.java
@@ -7,8 +7,10 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import java.util.Calendar;
+import java.util.Date;
 
 import sun.bob.mcalendarview.CellConfig;
+import sun.bob.mcalendarview.listeners.OnDateClickListener;
 import sun.bob.mcalendarview.listeners.OnExpDateClickListener;
 import sun.bob.mcalendarview.listeners.OnMonthScrollListener;
 import sun.bob.mcalendarview.views.ExpCalendarView;
@@ -19,6 +21,7 @@ public class ExpMainActivity extends AppCompatActivity {
 
     private TextView YearMonthTv;
     private ExpCalendarView expCalendarView;
+    private DateData selectedDate;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -43,9 +46,20 @@ public class ExpMainActivity extends AppCompatActivity {
             }
         });
 
+        expCalendarView.setOnDateClickListener(new OnDateClickListener() {
+            @Override
+            public void onDateClick(View view, DateData date) {
+                expCalendarView.getMarkedDates().removeAdd();
+                expCalendarView.markDate(date);
+                selectedDate = date;
+            }
+        });
+
         imageInit();
 
-        expCalendarView.markDate(2016, 10, 16);
+        Calendar calendar = Calendar.getInstance();
+        selectedDate = new DateData(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.DAY_OF_MONTH));
+        expCalendarView.markDate(selectedDate);
     }
 
     private boolean ifExpand = true;
@@ -59,6 +73,7 @@ public class ExpMainActivity extends AppCompatActivity {
                     CellConfig.Month2WeekPos = CellConfig.middlePosition;
                     CellConfig.ifMonth = false;
                     expandIV.setImageResource(R.mipmap.icon_arrow_down);
+                    CellConfig.weekAnchorPointDate = selectedDate;
                     expCalendarView.shrink();
                 } else {
                     CellConfig.Week2MonthPos = CellConfig.middlePosition;

--- a/mcalendarview/src/main/java/sun/bob/mcalendarview/CellConfig.java
+++ b/mcalendarview/src/main/java/sun/bob/mcalendarview/CellConfig.java
@@ -22,4 +22,6 @@ public class CellConfig {
     // 所以分成了两个
     public static DateData w2mPointDate;
     public static DateData m2wPointDate;
+
+    public static DateData weekAnchorPointDate;
 }

--- a/mcalendarview/src/main/java/sun/bob/mcalendarview/vo/MonthWeekData.java
+++ b/mcalendarview/src/main/java/sun/bob/mcalendarview/vo/MonthWeekData.java
@@ -1,6 +1,7 @@
 package sun.bob.mcalendarview.vo;
 
 import android.graphics.Color;
+import android.support.annotation.NonNull;
 import android.util.Log;
 
 import java.util.ArrayList;
@@ -30,11 +31,15 @@ public class MonthWeekData {
     public MonthWeekData(int position) {
         realPosition = position;
         calendar = Calendar.getInstance();
+        DateData today = new DateData(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.DAY_OF_MONTH));
         if (CellConfig.m2wPointDate == null) {
-            CellConfig.m2wPointDate = new DateData(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.DAY_OF_MONTH));
+            CellConfig.m2wPointDate = today;
         }
         if (CellConfig.w2mPointDate == null) {
-            CellConfig.w2mPointDate = new DateData(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.DAY_OF_MONTH));
+            CellConfig.w2mPointDate = today;
+        }
+        if (CellConfig.weekAnchorPointDate == null) {
+            CellConfig.weekAnchorPointDate = today;
         }
 
         if (CellConfig.ifMonth) {
@@ -138,7 +143,7 @@ public class MonthWeekData {
             calendar.add(Calendar.MONTH, distance);
         }
         // 如果是今天的月份，则锚点的日期为今天； 如果不是今天的月份，则锚点的日期为1号
-        calendar.set(Calendar.DAY_OF_MONTH, ifThisMonth());
+        calendar.set(Calendar.DAY_OF_MONTH, getAnchorDayOfMonth(CellConfig.weekAnchorPointDate));
 ///////////////////////////////////////////////////////////////////////////////////////////
         // 下面是：获得该页的锚点后，判断三页显示的内容，中间和两边页显示不同
         if (realPosition == CellConfig.Month2WeekPos) {
@@ -164,16 +169,20 @@ public class MonthWeekData {
         }
     }
 
-    private int ifThisMonth() {
+    private int getAnchorDayOfMonth(DateData date) {
         int thisMonth = Calendar.getInstance().get(Calendar.MONTH);
-//        Log.e("","================================");
-//        Log.e("",calendar.get(Calendar.MONTH)+" "+thisMonth);
-//        Log.e("","================================");
-        if (calendar.get(Calendar.MONTH) == thisMonth) {
-            return Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
-        } else {
-            return 1;
+        int month = date.getMonth() - 1;
+        int selectedMonth = calendar.get(Calendar.MONTH);
+        if (selectedMonth == month && calendar.get(Calendar.YEAR) == date.getYear()) {
+            return date.getDay();
         }
+
+        if (selectedMonth == thisMonth && month != thisMonth) {
+            Calendar calendar = Calendar.getInstance();
+            return calendar.get(Calendar.DAY_OF_MONTH);
+        }
+
+        return 1;
     }
 
     public ArrayList getData() {

--- a/mcalendarview/src/main/java/sun/bob/mcalendarview/vo/MonthWeekData.java
+++ b/mcalendarview/src/main/java/sun/bob/mcalendarview/vo/MonthWeekData.java
@@ -52,7 +52,7 @@ public class MonthWeekData {
 
     private void getPointDate() {
         // 获得收缩后的那个point
-        calendar.set(CellConfig.w2mPointDate.getYear(), CellConfig.w2mPointDate.getMonth() - 1, 1);
+        calendar.set(CellConfig.w2mPointDate.getYear(), CellConfig.w2mPointDate.getMonth() - 1, CellConfig.w2mPointDate.getDay());
         // 获得周的相对滑动的页面差
         int distance = CellConfig.Week2MonthPos - CellConfig.Month2WeekPos;
         calendar.add(Calendar.DATE, distance * 7);


### PR DESCRIPTION
- I added the possibility to choose which week of the month to show after shrink(). Simple use case:  the calendar is expanded, the user marks a date and then shrinks it, the week with the selected date should be visible (it was always the current week or the first of the month).

- There was a bug with the expansion after scrolling weeks. When you scroll the week view couple of times and go to another month, then expand the calendar it didn't show the new month. 